### PR TITLE
Added interleaved thinking

### DIFF
--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -274,6 +274,10 @@ export class AnthropicModel extends BaseModel {
                   };
                 }
                 case "server_tool_use":
+                case "mcp_tool_use":
+                case "mcp_tool_result":
+                case "code_execution_tool_result":
+                case "container_upload":
                 case "web_search_tool_result": {
                   return null;
                 }


### PR DESCRIPTION
Currently on an agent loop the agent only does a single `thinking` content (e.g. we had a 1-thinking, 136000+ token agent loop with 101 tool calls). This enables interleaved thinking so the model can reason between tool outputs.


Note: (This means we're using the `beta` anthropic SDK, this is why there are more `content` types that were added in the switch statement.