### PR TITLE
Small Refactor

### DIFF
--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -6,7 +6,6 @@ import {
   Tool,
   ToolChoice,
   TokenUsage,
-  DEFAULT_MAX_TOKENS,
 } from "./index";
 import Anthropic from "@anthropic-ai/sdk";
 import { normalizeError, SrchdError } from "../lib/error";
@@ -14,6 +13,7 @@ import { Err, Ok, Result } from "../lib/result";
 import { assertNever } from "../lib/assert";
 import { removeNulls } from "../lib/utils";
 
+const DEFAULT_MAX_TOKENS = 4096;
 const DEFAULT_LOW_THINKING_TOKENS = 4096;
 const DEFAULT_HIGH_THINKING_TOKENS = 8192;
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,8 +8,6 @@ export function isProvider(str: string): str is provider {
   return ["gemini", "anthropic", "openai", "mistral"].includes(str);
 }
 
-export const DEFAULT_MAX_TOKENS = 4096;
-
 export type ProviderData = Partial<Record<provider, any>>;
 
 export type TokenUsage = {
@@ -51,14 +49,6 @@ export interface ToolResult {
 export interface Message {
   role: "user" | "agent";
   content: (TextContent | ToolUse | ToolResult | Thinking)[];
-}
-
-export function isUserMessageWithText(
-  message: Message,
-): message is Message & { content: TextContent[] } {
-  return (
-    message.role === "user" && message.content.every((c) => c.type === "text")
-  );
 }
 
 export type ThinkingConfig = "high" | "low" | "none";


### PR DESCRIPTION
- Removed unused `isUserMessageWithText` function.
- Moved `DEFAULT_MAX_TOKENS` which was only used by anthropic from `index.ts` to `anthropic.ts`.