### PR TITLE
fix: sqllit crash on initing experiment

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,8 +1,17 @@
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import Database from "better-sqlite3";
 import * as schema from "./schema";
 
 const sqlite = new Database("./db.sqlite");
 export const db = drizzle({ client: sqlite, schema });
+
+// Run migrations on initialization with error handling
+try {
+  migrate(db, { migrationsFolder: "./src/migrations" });
+} catch (error) {
+  console.error("Failed to run database migrations:", error);
+  throw error;
+}
 
 export type Tx = Parameters<Parameters<(typeof db)["transaction"]>[0]>[0];


### PR DESCRIPTION
When the user tries to create an experiment with: 
```
npx tsx src/srchd.ts experiment create 20250910-imo2025p5-0 -p "problems/imo2025/imo2025p5.problem"
```

one is confrontend with SQLITE_ERROR due to not automatially running migrations:

>  ➜ npx tsx src/srchd.ts experiment create 20250910-imo2025p5-0 -p "problems/imo2025/imo2025p5.problem"
> Creating experiment: 20250910-imo2025p5-0
> 
> ./srchd/node_modules/better-sqlite3/lib/methods/wrappers.js:5
> 	return this[cppdb].prepare(sql, this, false);
> 	                   ^
> SqliteError: no such table: experiments
>     at Database.prepare (./srchd/node_modules/better-sqlite3/lib/methods/wrappers.js:5:21)
>     at BetterSQLiteSession.prepareQuery (./srchd/node_modules/src/better-sqlite3/session.ts:60:28)
>     at BetterSQLiteSession.prepareOneTimeQuery (./srchd/node_modules/src/sqlite-core/session.ts:251:15)
>     at QueryPromise._prepare (./srchd/node_modules/src/sqlite-core/query-builders/insert.ts:380:78)
>     at QueryPromise.all (./srchd/node_modules/src/sqlite-core/query-builders/insert.ts:402:15)
>     at QueryPromise.execute (./srchd/node_modules/src/sqlite-core/query-builders/insert.ts:414:40)
>     at QueryPromise.then (./srchd/node_modules/src/query-promise.ts:31:15) {
>   code: 'SQLITE_ERROR'
> }
> 

Node.js v22.20.0

One needs to manually run:
```
npx drizzle-kit migrate
```

With this change this won't be necessary. However I'm not sure of the implications of this. So maybe another option would be to update the readme to mention this. I see that the AGENTS.md is mentioning drizzle, yet the README for humans doesn't. :D 