### PR TITLE
Included Cache creation in A// token-counting.

### DIFF
--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -255,12 +255,18 @@ export class AnthropicModel extends BaseModel {
         betas: ["interleaved-thinking-2025-05-14"],
       });
 
+      const input =
+        message.usage.input_tokens +
+        (message.usage.cache_read_input_tokens ?? 0) +
+        (message.usage.cache_creation?.ephemeral_1h_input_tokens ?? 0) +
+        (message.usage.cache_creation?.ephemeral_5m_input_tokens ?? 0);
+
       const tokenUsage = {
-        total: message.usage.output_tokens + message.usage.input_tokens,
-        input: message.usage.input_tokens,
+        total: message.usage.output_tokens + input,
+        input,
         output: message.usage.output_tokens,
         cached: message.usage.cache_read_input_tokens ?? 0,
-        thinking: 0,
+        thinking: 0, // Anthropic doesn't give thinking token usage
         cost: this.cost(message.usage),
       };
       // console.log(message.usage);


### PR DESCRIPTION
The A// [token-usage doc](https://docs.claude.com/en/api/messages#response-usage) says:

> Total input tokens in a request is the summation of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.

So this PR just fixes the calculation of input tokens.