### PR TITLE
Make srchd instances with Kubernetes Pods

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from 'drizzle-kit';
+import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  dialect: 'sqlite',
-  schema: './src/db/schema.ts',
-  out: './src/migrations',
+  dialect: "sqlite",
+  schema: "./src/db/schema.ts",
+  out: "./src/migrations",
   dbCredentials: {
-    url: './db.sqlite',
+    url: process.env.DATABASE_PATH ?? "./db.sqlite",
   },
 });

--- a/scripts/test-workspaces.sh
+++ b/scripts/test-workspaces.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+
+num_workspaces=${1:-1}
+
+function browse() {
+  url=$1
+  if command -v xdg-open &> /dev/null; then
+    xdg-open "$url"
+  elif command -v open &> /dev/null; then
+    open "$url"
+  else
+    echo "No browser opener found (xdg-open or open)"
+  fi
+}
+
+alias workspace="npx tsx src/srchd.ts workspace"
+
+function srchd() {
+  workspace_id=$1
+  kubectl exec -it srchd-$workspace_id -n $workspace_id -- npx tsx src/srchd.ts "${@:2}"
+}
+
+function check_pod() {
+  workspace_id=$1
+  pod_name=$2
+  kubectl get pods -n $workspace_id | awk '{print $1}' | grep -q $pod_name
+}
+
+function check_image() {
+  image_name=$1
+  source=$2
+  tagless_image=$(echo $image_name | sed 's/\:.*$//g')
+  echo Checking if $tagless_image docker image is built...
+  if docker images | grep -q $tagless_image; then
+    echo $tagless_image image found.
+  else
+    echo $tagless_image image not found. Building...
+    docker build -t $image_name $source
+  fi
+}
+
+function validate_test() {
+  workspace_id=$1
+  echo Checking computers were created
+  all="true"
+
+  if check_pod $workspace_id srchd-$workspace_id-test-gpt; then
+    echo "GPT Pod running..."
+  else
+    all="false"
+  fi
+  if check_pod $workspace_id srchd-$workspace_id-test-gemini; then
+    echo "Gemini Pod running..."
+  else
+    all="false"
+  fi
+  if check_pod $workspace_id srchd-$workspace_id-test-mistral; then
+    echo "Mistral Pod running..."
+  else
+    all="false"
+  fi
+
+  if [ "$all" != "true" ]; then
+    echo "Missing computers"
+    echo TEST FAILED
+  else
+    echo TEST SUCCEEDED
+  fi
+}
+
+
+function run_agents() {
+  workspace_id=$1
+  timeout_sec=$2
+  echo Running agents for $2 seconds.
+  python3 -c "
+import subprocess
+import sys
+import os
+import signal
+import time
+
+print('workspaceId: $workspace_id')
+cmd = ['kubectl', 'exec', '-t', 'srchd-$workspace_id', '-n', '$workspace_id', '--', 'npx', 'tsx', 'src/srchd.ts', 'agent',
+'run', 'all', '-e', 'test']
+print(f'Executing cmd: {cmd}')
+
+# Start process in new process group
+proc = subprocess.Popen(cmd,
+    stdin=sys.stdin,
+    stdout=sys.stdout,
+    stderr=sys.stderr,
+    preexec_fn=os.setpgrp  # Create new process group
+)
+
+try:
+    proc.wait(timeout=$timeout_sec)
+except subprocess.TimeoutExpired:
+    print('Timeout reached, stopping agents...')
+    # Kill entire process group
+    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    time.sleep(2)
+    # Force kill if still alive
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+except KeyboardInterrupt:
+    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    sys.exit(1)
+"
+  echo Done.
+}
+
+function test_workspace() {
+  workspace_id=$1
+  workspace create $workspace_id
+  sleep 5
+  if ! check_pod $workspace_id srchd-$workspace_id; then
+    echo "Could not deploy"
+  fi
+  echo "Starting server..."
+  workspace connect $workspace_id &
+  server_pid=$!
+  sleep 2
+  echo Creating $workspace_id experiment
+  srchd $workspace_id experiment create test -p problems/security/tor.problem
+  echo Creating agent for 3 providers
+  srchd $workspace_id agent create -p openai -m gpt-5 -t high --tool web --tool computer -s prompts/researcher.md -e test -n gpt
+  srchd $workspace_id agent create -p gemini -m gemini-2.5-flash -t low --tool web --tool computer -s prompts/researcher.md -e test -n gemini
+  srchd $workspace_id agent create -p mistral -m mistral-large-latest -t none --tool web --tool computer -s prompts/researcher.md -e test -n mistral
+
+  browse "http://localhost:1337/experiments/1"
+
+  run_agents $workspace_id 30
+  echo "Stopping server..."
+  kill $server_pid
+  validate_test $workspace_id
+  workspace delete $workspace_id
+}
+
+check_image "agent-computer:base" ./src/computer
+check_image "srchd:latest" .
+
+for i in $(seq 1 $num_workspaces); do
+  test_workspace "test$i"
+done
+
+echo Test complete.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,7 +2,8 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 import * as schema from "./schema";
 
-const sqlite = new Database("./db.sqlite");
+const dbPath = process.env.DATABASE_PATH ?? "./db.sqlite";
+const sqlite = new Database(dbPath);
 export const db = drizzle({ client: sqlite, schema });
 
 export type Tx = Parameters<Parameters<(typeof db)["transaction"]>[0]>[0];

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -23,6 +23,8 @@ export type ErrorCode =
   | "web_search_error"
   | "pod_deletion_error"
   | "pod_initialization_error"
+  | "namespace_deletion_error"
+  | "port_forward_error"
   | "string_edit_error";
 
 export class SrchdError<T extends ErrorCode = ErrorCode> extends Error {

--- a/src/workspace/definitions.ts
+++ b/src/workspace/definitions.ts
@@ -1,0 +1,155 @@
+import * as k8s from "@kubernetes/client-node";
+import { ApiKeys } from ".";
+import {
+  namespaceLabels,
+  podName,
+  serviceAccountName,
+  serviceName,
+  volumeName,
+} from "../lib/k8s";
+
+const SRCHD_IMAGE = "srchd:latest";
+
+export function defineServerService(workspaceId: string): k8s.V1Service {
+  return {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      name: serviceName(workspaceId),
+      namespace: workspaceId,
+      labels: namespaceLabels(workspaceId),
+    },
+    spec: {
+      selector: {
+        ...namespaceLabels(workspaceId),
+        "srchd.io/type": "server",
+      },
+      ports: [
+        {
+          port: 1337,
+          targetPort: 1337,
+          name: "http",
+        },
+      ],
+      type: "ClusterIP",
+    },
+  };
+}
+
+export function defineServerVolume(
+  workspaceId: string,
+): k8s.V1PersistentVolumeClaim {
+  return {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: {
+      name: volumeName(workspaceId),
+      namespace: workspaceId,
+      labels: namespaceLabels(workspaceId),
+    },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      resources: {
+        requests: {
+          storage: "5Gi",
+        },
+      },
+    },
+  };
+}
+
+export function defineServerPod(
+  workspaceId: string,
+  apiKeys: ApiKeys,
+): k8s.V1Pod {
+  return {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: podName(workspaceId),
+      namespace: workspaceId,
+      labels: {
+        ...namespaceLabels(workspaceId),
+        "srchd.io/type": "server",
+      },
+    },
+    spec: {
+      serviceAccountName: serviceAccountName(workspaceId),
+      restartPolicy: "Always",
+      containers: [
+        {
+          name: "srchd",
+          image: SRCHD_IMAGE,
+          imagePullPolicy: "IfNotPresent",
+          env: defineServerEnv(workspaceId, apiKeys),
+          ports: [
+            {
+              containerPort: 1337,
+              name: "http",
+            },
+          ],
+          volumeMounts: [
+            {
+              name: "data",
+              mountPath: "/data",
+            },
+          ],
+        },
+      ],
+      volumes: [
+        {
+          name: "data",
+          persistentVolumeClaim: {
+            claimName: volumeName(workspaceId),
+          },
+        },
+      ],
+    },
+  };
+}
+
+export function defineServerEnv(
+  workspaceId: string,
+  apiKeys: ApiKeys,
+): k8s.V1EnvVar[] {
+  // Prepare environment variables
+  const env: k8s.V1EnvVar[] = [
+    { name: "NAMESPACE", value: workspaceId },
+    { name: "WORKSPACE_ID", value: workspaceId },
+    { name: "DATABASE_PATH", value: "/data/db.sqlite" },
+  ];
+
+  // Add API keys if provided
+  if (apiKeys?.anthropic || process.env.ANTHROPIC_API_KEY) {
+    env.push({
+      name: "ANTHROPIC_API_KEY",
+      value: apiKeys?.anthropic ?? process.env.ANTHROPIC_API_KEY,
+    });
+  }
+  if (apiKeys?.openai || process.env.OPENAI_API_KEY) {
+    env.push({
+      name: "OPENAI_API_KEY",
+      value: apiKeys?.openai ?? process.env.OPENAI_API_KEY,
+    });
+  }
+  if (apiKeys?.google || process.env.GOOGLE_API_KEY) {
+    env.push({
+      name: "GOOGLE_API_KEY",
+      value: apiKeys?.google ?? process.env.GOOGLE_API_KEY,
+    });
+  }
+  if (apiKeys?.mistral || process.env.MISTRAL_API_KEY) {
+    env.push({
+      name: "MISTRAL_API_KEY",
+      value: apiKeys?.mistral ?? process.env.MISTRAL_API_KEY,
+    });
+  }
+  if (apiKeys?.firecrawl || process.env.FIRECRAWL_API_KEY) {
+    env.push({
+      name: "FIRECRAWL_API_KEY",
+      value: apiKeys?.firecrawl ?? process.env.FIRECRAWL_API_KEY,
+    });
+  }
+
+  return env;
+}

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -1,0 +1,171 @@
+import * as k8s from "@kubernetes/client-node";
+import * as net from "net";
+import { Err, Ok, Result } from "../lib/result";
+import { SrchdError } from "../lib/error";
+import { ensureService, ensureServerPod, ensureServerVolume } from "./k8s";
+import path from "path";
+import {
+  ensureNamespace,
+  ensurePodRunning,
+  ensureRole,
+  ensureRoleBinding,
+  ensureServiceAccount,
+  k8sApi,
+  podName,
+} from "../lib/k8s";
+
+export const SRCHD_DOCKERFILE_PATH = path.join(__dirname, "../../Dockerfile");
+
+export interface ApiKeys {
+  anthropic?: string;
+  openai?: string;
+  google?: string;
+  mistral?: string;
+  firecrawl?: string;
+}
+
+export async function createWorkspace(
+  workspaceId: string,
+  apiKeys: ApiKeys,
+): Promise<Result<void, SrchdError>> {
+  let res = await ensureNamespace(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+  // Create RBAC resources
+  res = await ensureServiceAccount(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+  res = await ensureRole(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+  res = await ensureRoleBinding(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+
+  // Create Pod resources
+  res = await ensureServerVolume(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+  res = await ensureServerPod(workspaceId, apiKeys);
+  if (res.isErr()) {
+    return res;
+  }
+  res = await ensureService(workspaceId);
+  if (res.isErr()) {
+    return res;
+  }
+
+  console.log(`\nWaiting for pod to be ready...`);
+  res = await ensurePodRunning(workspaceId);
+
+  if (res.isOk()) {
+    console.log(`✓ Pod is ready and running`);
+  } else {
+    console.log(
+      `⚠ Pod may not be ready yet, check with: kubectl get pod ${podName(workspaceId)} -n ${workspaceId}`,
+    );
+  }
+  return res;
+}
+
+export async function deleteWorkspace(
+  workspaceId: string,
+): Promise<Result<void, SrchdError>> {
+  try {
+    const pods = await k8sApi.listNamespacedPod({
+      namespace: workspaceId,
+    });
+
+    // Delete all associated computers with it.
+    for (const pod of pods.items.filter((p) => p.metadata?.name)) {
+      await k8sApi.deleteNamespacedPod({
+        name: pod.metadata!.name!,
+        namespace: workspaceId,
+        gracePeriodSeconds: 0,
+      });
+    }
+
+    await k8sApi.deleteNamespace({
+      name: workspaceId,
+    });
+    return new Ok(undefined);
+  } catch (err: any) {
+    return new Err(
+      new SrchdError(
+        "namespace_deletion_error",
+        `Failed to delete namespace: ${workspaceId}`,
+        err,
+      ),
+    );
+  }
+}
+
+export async function listComputers(workspaceId: string): Promise<k8s.V1Pod[]> {
+  const pods = await k8sApi.listNamespacedPod({
+    namespace: workspaceId,
+  });
+
+  return pods.items.filter((pod) => pod.metadata?.labels?.computer);
+}
+
+export async function listWorkspaces(): Promise<k8s.V1Pod[]> {
+  const instances = await k8sApi.listPodForAllNamespaces({});
+  return instances.items.filter(
+    (i) =>
+      i.metadata?.labels?.app === "srchd" &&
+      i.metadata?.labels["srchd.io/type"] === "server",
+  );
+}
+
+export async function startPortForward(
+  workspaceId: string,
+  port: number,
+): Promise<Result<void, SrchdError>> {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromDefault();
+  const forward = new k8s.PortForward(kc);
+
+  const server = net
+    .createServer((socket) => {
+      forward.portForward(
+        workspaceId,
+        podName(workspaceId),
+        [1337],
+        socket,
+        socket,
+        socket,
+      );
+    })
+    .listen(port);
+
+  // Keep the process alive
+  return new Promise((resolve) => {
+    server.on("error", (err: Error) => {
+      console.error("Port forward error:", err);
+      resolve(
+        new Err(
+          new SrchdError("port_forward_error", `Port forward error: ${err}`),
+        ),
+      );
+    });
+
+    process.on("SIGINT", () => {
+      console.log("\nStopping port forward...");
+      server.close();
+      resolve(new Ok(undefined));
+      process.exit(0);
+    });
+
+    process.on("SIGTERM", () => {
+      console.log("\nStopping port forward...");
+      server.close();
+      resolve(new Ok(undefined));
+      process.exit(0);
+    });
+  });
+}

--- a/src/workspace/k8s.ts
+++ b/src/workspace/k8s.ts
@@ -1,0 +1,74 @@
+import { SrchdError } from "../lib/error";
+import {
+  defineServerService,
+  defineServerPod,
+  defineServerVolume,
+} from "./definitions";
+import { ApiKeys } from ".";
+import { Result } from "../lib/result";
+import { ensure, k8sApi, podName, serviceName, volumeName } from "../lib/k8s";
+
+export async function ensureService(
+  workspaceId: string,
+): Promise<Result<void, SrchdError>> {
+  return await ensure(
+    async () => {
+      await k8sApi.readNamespacedService({
+        name: serviceName(workspaceId),
+        namespace: workspaceId,
+      });
+    },
+    async () => {
+      await k8sApi.createNamespacedService({
+        namespace: workspaceId,
+        body: defineServerService(workspaceId),
+      });
+    },
+    "Service",
+    serviceName(workspaceId),
+  );
+}
+
+export async function ensureServerPod(
+  workspaceId: string,
+  apiKeys: ApiKeys,
+): Promise<Result<void, SrchdError>> {
+  return await ensure(
+    async () => {
+      await k8sApi.readNamespacedPod({
+        name: podName(workspaceId),
+        namespace: workspaceId,
+      });
+    },
+    async () => {
+      await k8sApi.createNamespacedPod({
+        namespace: workspaceId,
+        body: defineServerPod(workspaceId, apiKeys),
+      });
+    },
+    "Pod",
+    podName(workspaceId),
+  );
+}
+
+export async function ensureServerVolume(
+  workspaceId: string,
+): Promise<Result<void, SrchdError>> {
+  const name = volumeName(workspaceId);
+  return await ensure(
+    async () => {
+      await k8sApi.readNamespacedPersistentVolumeClaim({
+        name,
+        namespace: workspaceId,
+      });
+    },
+    async () => {
+      await k8sApi.createNamespacedPersistentVolumeClaim({
+        namespace: workspaceId,
+        body: defineServerVolume(workspaceId),
+      });
+    },
+    "PVC",
+    name,
+  );
+}


### PR DESCRIPTION
This builds upon https://github.com/dust-tt/srchd/pull/71

Now we can create a pod with an `workspaceId` to identify it.

This creates a kubernetes namespace which means all the `computer` pods will reside within this namespace, allowing them to communicate with the server's pod which is named `srchd-${workspaceId}`.

```bash
$ srchd workspace help
Usage: srchd workspace [options] [command]

Manage srchd workspaces

Options:
  -h, --help                display help for command

Commands:
  create [name]             Create a new srchd workspace
  computers <name>          list computers of a srchd workspace
  list                      List srchd workspaces
  delete <name>             Delete a srchd workspace
  connect [options] <name>  Port-forwards a Srchd workspace to a local port
  help [command]            display help for command
```

This also has a test file named `test-workspaces.sh` Which does the same thing as `test-pods` but with a server, and can do so for multiple servers at the same time.