### PR TITLE
Make `computer` cmd a generic `image` command to also build `srchd` instances.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-alpine
+
+# Install build dependencies for better-sqlite3
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package*.json ./
+COPY drizzle.config.ts .
+COPY tsconfig.json .
+RUN npm ci
+
+# Copy code and data
+COPY prompts prompts
+COPY problems problems
+COPY src src
+
+ENV DATABASE_PATH="/data/db.sqlite"
+
+# Environment variables for API keys
+ENV ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+ENV OPENAI_API_KEY=${OPENAI_API_KEY}
+ENV GOOGLE_API_KEY=${GOOGLE_API_KEY}
+ENV MISTRAL_API_KEY=${MISTRAL_API_KEY}
+ENV FIRECRAWL_API_KEY=${FIRECRAWL_API_KEY}
+
+EXPOSE 1337
+
+# Create DB, run migrations, and start server
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# THIS FILE IS ONLY INTENDED TO BE RUN IN THE DOCKER CONTAINER
+
+set -e
+
+# Initialize database if it doesn't exist or is empty
+DB_PATH="${DATABASE_PATH:-/app/db.sqlite}"
+if [ ! -s "$DB_PATH" ]; then
+  echo "Initializing database..."
+  mkdir -p "$(dirname "$DB_PATH")"
+  touch "$DB_PATH"
+  npx drizzle-kit push --config=drizzle.config.ts
+  echo "Database initialized."
+fi
+
+# Start the server
+npx tsx src/srchd.ts serve

--- a/src/computer/index.ts
+++ b/src/computer/index.ts
@@ -11,6 +11,9 @@ import { AgentResource } from "../resources/agent";
 import { podName, volumeName } from "../lib/k8s";
 import { ensureComputerPod, ensureComputerVolume, computerExec } from "./k8s";
 import { DEFAULT_WORKDIR } from "./definitions";
+import path from "path";
+
+export const COMPUTER_DOCKERFILE_PATH = path.join(__dirname, "Dockerfile");
 
 export function computerId(
   experiment: ExperimentResource,

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -18,7 +18,7 @@ export type ErrorCode =
   | "pod_run_error"
   | "computer_run_error"
   | "pod_timeout_error"
-  | "computer_image_error"
+  | "image_error"
   | "web_fetch_error"
   | "web_search_error"
   | "pod_deletion_error"

--- a/src/srchd.ts
+++ b/src/srchd.ts
@@ -27,12 +27,8 @@ import {
   publicationMetricsByExperiment,
 } from "./metrics";
 import { ExperimentMetrics } from "./metrics";
-import {
-  buildImage,
-  dockerFile,
-  dockerFileForIdentity,
-} from "./computer/image";
 import { Computer, computerId } from "./computer";
+import { buildImage, dockerFile, dockerFileForIdentity } from "./lib/image";
 
 const exitWithError = (err: Err<SrchdError>) => {
   console.error(
@@ -600,32 +596,34 @@ agentCmd
   });
 
 // Computer command
-const imageCmd = program.command("computer").description("Computer tool utils");
+const imageCmd = program.command("image").description("Docker image utils");
 
 imageCmd
-  .command("image-build")
-  .description("Build the agent computer Docker image")
+  .command("build")
+  .description("Build a Docker image")
+  .argument("[image]: computer | srchd", "Image to build (default: computer)")
   .option(
     "-i, --identity <private_key_path>",
-    "Path to SSH private key for Git access",
+    "Path to SSH private key for Git access (Only for computer image)",
   )
-  .action(async (options) => {
-    const res = await buildImage(options.identity);
+  .action(async (image, options) => {
+    const res = await buildImage(image, options.identity);
     if (res.isErr()) {
       return exitWithError(res);
     }
 
-    console.log("Agent computer Docker image built successfully.");
+    console.log(`${image} Docker image built successfully.`);
   });
 
 imageCmd
-  .command("image-show")
-  .description("Dump the agent computer Docker image")
+  .command("show")
+  .description("Dump the Docker image")
+  .argument("[image]: computer | srchd", "Image to dump (default: computer)")
   .option(
     "-i, --identity <private_key_path>",
     "Path to SSH private key for Git access",
   )
-  .action(async (options) => {
+  .action(async (image, options) => {
     if (options.identity) {
       const res = await dockerFileForIdentity(options.identity);
       if (res.isErr()) {
@@ -633,7 +631,7 @@ imageCmd
       }
       console.log(res.value);
     } else {
-      console.log(await dockerFile());
+      console.log(await dockerFile(image));
     }
   });
 

--- a/src/tools/computer.ts
+++ b/src/tools/computer.ts
@@ -6,7 +6,7 @@ import { ExperimentResource } from "../resources/experiment";
 import { SrchdError } from "../lib/error";
 import { Computer, computerId } from "../computer";
 import { COMPUTER_SERVER_NAME as SERVER_NAME } from "../tools/constants";
-import { dockerFile } from "../computer/image";
+import { dockerFile } from "../lib/image";
 
 const SERVER_VERSION = "0.1.0";
 
@@ -14,7 +14,7 @@ export async function createComputerServer(
   experiment: ExperimentResource,
   agent: AgentResource,
 ): Promise<McpServer> {
-  const df = await dockerFile();
+  const df = await dockerFile("computer");
 
   const server = new McpServer({
     name: SERVER_NAME,


### PR DESCRIPTION
All in the title
```bash
Usage: srchd image [options] [command]

Docker image utils

Options:
  -h, --help                                 display help for command

Commands:
  build [options] [image]: computer | srch]  Build a Docker image
  show [options] [image]: computer | srch]   Dump the Docker image
  help [command]                             display help for command
```