### PR TITLE
Added Cost-calculation for OpenAI

### DIFF
--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -36,7 +36,7 @@ function normalizeTokenPrices(
   };
 }
 
-// https://docs.claude.com/en/docs/about-claude/pricing#model-pricing
+// https://platform.openai.com/docs/pricing
 const TOKEN_PRICING: Record<OpenAIModels, OpenAITokenPrices> = {
   "gpt-5": normalizeTokenPrices(1.25, 10),
   "gpt-5-mini": normalizeTokenPrices(0.25, 2),


### PR DESCRIPTION
Note: this isn't displayed or used anywhere for now.

(You can check it works by appending a `console.log` to the `cost` method.