### PR TITLE
Renaming Nits

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,12 +6,12 @@ import {
   index,
 } from "drizzle-orm/sqlite-core";
 import { Message, provider, ThinkingConfig } from "../models";
-import { AnthropicModels } from "../models/anthropic";
-import { GeminiModels } from "../models/gemini";
-import { OpenAIModels } from "../models/openai";
-import { MistralModels } from "../models/mistral";
+import { AnthropicModel } from "../models/anthropic";
+import { GeminiModel } from "../models/gemini";
+import { OpenAIModel } from "../models/openai";
+import { MistralModel } from "../models/mistral";
 import { ToolName } from "../tools/constants";
-import { MoonshotAIModels } from "../models/moonshotai";
+import { MoonshotAIModel } from "../models/moonshotai";
 
 export const experiments = sqliteTable(
   "experiments",
@@ -76,11 +76,11 @@ export const agents = sqliteTable(
     provider: text("provider").$type<provider>().notNull(),
     model: text("model")
       .$type<
-        | AnthropicModels
-        | GeminiModels
-        | OpenAIModels
-        | MistralModels
-        | MoonshotAIModels
+        | AnthropicModel
+        | GeminiModel
+        | OpenAIModel
+        | MistralModel
+        | MoonshotAIModel
       >()
       .notNull(),
     thinking: text("thinking").$type<ThinkingConfig>().notNull(),

--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -1,6 +1,6 @@
 import { MessageParam } from "@anthropic-ai/sdk/resources/messages";
 import {
-  BaseModel,
+  LLM,
   ModelConfig,
   Message,
   Tool,
@@ -41,17 +41,17 @@ function normalizeTokenPrices(
 }
 
 // https://docs.claude.com/en/docs/about-claude/pricing#model-pricing
-const TOKEN_PRICING: Record<AnthropicModels, AnthropicTokenPrices> = {
+const TOKEN_PRICING: Record<AnthropicModel, AnthropicTokenPrices> = {
   "claude-opus-4-1-20250805": normalizeTokenPrices(15, 75),
   "claude-sonnet-4-5-20250929": normalizeTokenPrices(15, 75),
   "claude-haiku-4-5-20251001": normalizeTokenPrices(1, 5),
 };
 
-export type AnthropicModels =
+export type AnthropicModel =
   | "claude-opus-4-1-20250805"
   | "claude-sonnet-4-5-20250929"
   | "claude-haiku-4-5-20251001";
-export function isAnthropicModel(model: string): model is AnthropicModels {
+export function isAnthropicModel(model: string): model is AnthropicModel {
   return [
     "claude-opus-4-1-20250805",
     "claude-sonnet-4-5-20250929",
@@ -59,13 +59,13 @@ export function isAnthropicModel(model: string): model is AnthropicModels {
   ].includes(model);
 }
 
-export class AnthropicModel extends BaseModel {
+export class AnthropicLLM extends LLM {
   private client: Anthropic;
-  private model: AnthropicModels;
+  private model: AnthropicModel;
 
   constructor(
     config: ModelConfig,
-    model: AnthropicModels = "claude-sonnet-4-5-20250929",
+    model: AnthropicModel = "claude-sonnet-4-5-20250929",
   ) {
     super(config);
     this.client = new Anthropic({

--- a/src/models/gemini.ts
+++ b/src/models/gemini.ts
@@ -6,7 +6,7 @@ import {
   GoogleGenAI,
 } from "@google/genai";
 import {
-  BaseModel,
+  LLM,
   ModelConfig,
   Message,
   Tool,
@@ -20,11 +20,11 @@ import { normalizeError, SrchdError } from "../lib/error";
 import { assertNever } from "../lib/assert";
 import { removeNulls } from "../lib/utils";
 
-export type GeminiModels =
+export type GeminiModel =
   | "gemini-2.5-pro"
   | "gemini-2.5-flash"
   | "gemini-2.5-flash-lite";
-export function isGeminiModel(model: string): model is GeminiModels {
+export function isGeminiModel(model: string): model is GeminiModel {
   return [
     "gemini-2.5-pro",
     "gemini-2.5-flash",
@@ -48,19 +48,19 @@ function normalizeTokenPrices(
 }
 
 // https://ai.google.dev/gemini-api/docs/pricing
-const TOKEN_PRICING: Record<GeminiModels, GeminiTokenPrices> = {
+const TOKEN_PRICING: Record<GeminiModel, GeminiTokenPrices> = {
   "gemini-2.5-pro": normalizeTokenPrices(1.25, 10),
   "gemini-2.5-flash": normalizeTokenPrices(0.3, 2.5),
   "gemini-2.5-flash-lite": normalizeTokenPrices(0.1, 0.4),
 };
 
-export class GeminiModel extends BaseModel {
+export class GeminiLLM extends LLM {
   private client: GoogleGenAI;
-  private model: GeminiModels;
+  private model: GeminiModel;
 
   constructor(
     config: ModelConfig,
-    model: GeminiModels = "gemini-2.5-flash-lite",
+    model: GeminiModel = "gemini-2.5-flash-lite",
   ) {
     super(config);
     this.client = new GoogleGenAI({});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -76,7 +76,7 @@ export interface Tool {
 
 export type ToolChoice = "auto" | "any" | "none";
 
-export abstract class BaseModel {
+export abstract class LLM {
   protected config: ModelConfig;
 
   constructor(config: ModelConfig) {

--- a/src/models/mistral.ts
+++ b/src/models/mistral.ts
@@ -1,5 +1,5 @@
 import {
-  BaseModel,
+  LLM,
   ModelConfig,
   Message,
   Tool,
@@ -38,18 +38,18 @@ function normalizeTokenPrices(
 }
 
 // https://mistral.ai/pricing#api-pricing
-const TOKEN_PRICING: Record<MistralModels, MistralTokenPrices> = {
+const TOKEN_PRICING: Record<MistralModel, MistralTokenPrices> = {
   "mistral-large-latest": normalizeTokenPrices(2, 6),
   "mistral-small-latest": normalizeTokenPrices(0.1, 0.3),
   "codestral-latest": normalizeTokenPrices(0.3, 0.9),
 };
 
-export type MistralModels =
+export type MistralModel =
   | "mistral-large-latest"
   | "mistral-small-latest"
   | "codestral-latest";
 
-export function isMistralModel(model: string): model is MistralModels {
+export function isMistralModel(model: string): model is MistralModel {
   return [
     "mistral-large-latest",
     "mistral-small-latest",
@@ -74,13 +74,13 @@ function validateName(name: string): { valid: boolean; reason?: string } {
   return { valid: true };
 }
 
-export class MistralModel extends BaseModel {
+export class MistralLLM extends LLM {
   private client: Mistral;
-  private model: MistralModels;
+  private model: MistralModel;
 
   constructor(
     config: ModelConfig,
-    model: MistralModels = "mistral-large-latest",
+    model: MistralModel = "mistral-large-latest",
   ) {
     super(config);
     this.client = new Mistral();

--- a/src/models/moonshotai.ts
+++ b/src/models/moonshotai.ts
@@ -3,7 +3,7 @@ import {
   ChatCompletionMessageParam,
 } from "openai/resources/chat";
 import {
-  BaseModel,
+  LLM,
   ModelConfig,
   Message,
   Tool,
@@ -19,8 +19,8 @@ import { removeNulls } from "../lib/utils";
 import { convertThinking, convertToolChoice } from "./openai";
 import { CompletionUsage } from "openai/resources/completions";
 
-export type MoonshotAIModels = "kimi-k2-thinking";
-export function isMoonshotAIModel(model: string): model is MoonshotAIModels {
+export type MoonshotAIModel = "kimi-k2-thinking";
+export function isMoonshotAIModel(model: string): model is MoonshotAIModel {
   return ["kimi-k2-thinking"].includes(model);
 }
 
@@ -43,17 +43,17 @@ function normalizeTokenPrices(
 }
 
 // https://platform.moonshot.ai/docs/pricing/chat#product-pricing
-const TOKEN_PRICING: Record<MoonshotAIModels, MoonshotAITokenPrices> = {
+const TOKEN_PRICING: Record<MoonshotAIModel, MoonshotAITokenPrices> = {
   "kimi-k2-thinking": normalizeTokenPrices(0.6, 2.5, 0.15),
 };
 
-export class MoonshotAIModel extends BaseModel {
+export class MoonshotAILLM extends LLM {
   private client: OpenAI;
-  private model: MoonshotAIModels;
+  private model: MoonshotAIModel;
 
   constructor(
     config: ModelConfig,
-    model: MoonshotAIModels = "kimi-k2-thinking",
+    model: MoonshotAIModel = "kimi-k2-thinking",
   ) {
     super(config);
     this.client = new OpenAI({

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -3,7 +3,7 @@ import {
   ResponseUsage,
 } from "openai/resources/responses/responses";
 import {
-  BaseModel,
+  LLM,
   ModelConfig,
   Message,
   Tool,
@@ -37,7 +37,7 @@ function normalizeTokenPrices(
 }
 
 // https://platform.openai.com/docs/pricing
-const TOKEN_PRICING: Record<OpenAIModels, OpenAITokenPrices> = {
+const TOKEN_PRICING: Record<OpenAIModel, OpenAITokenPrices> = {
   "gpt-5": normalizeTokenPrices(1.25, 10),
   "gpt-5-mini": normalizeTokenPrices(0.25, 2),
   "gpt-5-nano": normalizeTokenPrices(0.05, 0.4),
@@ -72,13 +72,13 @@ export function convertThinking(thinking: "high" | "low" | "none" | undefined) {
   }
 }
 
-export type OpenAIModels =
+export type OpenAIModel =
   | "gpt-5"
   | "gpt-5-mini"
   | "gpt-5-nano"
   | "gpt-4.1"
   | "gpt-5-codex";
-export function isOpenAIModel(model: string): model is OpenAIModels {
+export function isOpenAIModel(model: string): model is OpenAIModel {
   return [
     "gpt-5-codex",
     "gpt-5",
@@ -88,11 +88,11 @@ export function isOpenAIModel(model: string): model is OpenAIModels {
   ].includes(model);
 }
 
-export class OpenAIModel extends BaseModel {
+export class OpenAILLM extends LLM {
   private client: OpenAI;
-  private model: OpenAIModels;
+  private model: OpenAIModel;
 
-  constructor(config: ModelConfig, model: OpenAIModels = "gpt-5-mini") {
+  constructor(config: ModelConfig, model: OpenAIModel = "gpt-5-mini") {
     super(config);
     this.client = new OpenAI();
     this.model = model;

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7 } from "json-schema";
 import {
-  BaseModel,
+  LLM,
   Message,
   TextContent,
   Thinking,
@@ -19,22 +19,22 @@ import { PublicationResource } from "../resources/publication";
 import { renderListOfPublications } from "../tools/publications";
 import { createClientServerPair, errorToCallToolResult } from "../lib/mcp";
 import { concurrentExecutor } from "../lib/async";
-import { AnthropicModel, AnthropicModels } from "../models/anthropic";
+import { AnthropicLLM, AnthropicModel } from "../models/anthropic";
 import { assertNever } from "../lib/assert";
-import { GeminiModel, GeminiModels } from "../models/gemini";
-import { OpenAIModel, OpenAIModels } from "../models/openai";
-import { MistralModel, MistralModels } from "../models/mistral";
+import { GeminiLLM, GeminiModel } from "../models/gemini";
+import { OpenAILLM, OpenAIModel } from "../models/openai";
+import { MistralLLM, MistralModel } from "../models/mistral";
 import { TokenUsageResource } from "../resources/token_usage";
 import { createServer } from "../tools";
 import { DEFAULT_TOOLS } from "../tools/constants";
-import { MoonshotAIModel, MoonshotAIModels } from "../models/moonshotai";
+import { MoonshotAILLM, MoonshotAIModel } from "../models/moonshotai";
 import { RunConfig } from "./config";
 
 export class Runner {
   private experiment: ExperimentResource;
   private agent: AgentResource;
   private mcpClients: Client[];
-  private model: BaseModel;
+  private model: LLM;
 
   private contextPruning: {
     lastAgentLoopStartIdx: number;
@@ -46,7 +46,7 @@ export class Runner {
     experiment: ExperimentResource,
     agent: AgentResource,
     mcpClients: Client[],
-    model: BaseModel,
+    model: LLM,
   ) {
     this.experiment = experiment;
     this.agent = agent;
@@ -106,39 +106,39 @@ export class Runner {
       const provider = agent.toJSON().provider;
       switch (provider) {
         case "anthropic":
-          return new AnthropicModel(
+          return new AnthropicLLM(
             {
               thinking: agent.toJSON().thinking,
             },
-            agent.toJSON().model as AnthropicModels,
+            agent.toJSON().model as AnthropicModel,
           );
         case "gemini":
-          return new GeminiModel(
+          return new GeminiLLM(
             {
               thinking: agent.toJSON().thinking,
             },
-            agent.toJSON().model as GeminiModels,
+            agent.toJSON().model as GeminiModel,
           );
         case "openai":
-          return new OpenAIModel(
+          return new OpenAILLM(
             {
               thinking: agent.toJSON().thinking,
             },
-            agent.toJSON().model as OpenAIModels,
+            agent.toJSON().model as OpenAIModel,
           );
         case "mistral":
-          return new MistralModel(
+          return new MistralLLM(
             {
               thinking: agent.toJSON().thinking,
             },
-            agent.toJSON().model as MistralModels,
+            agent.toJSON().model as MistralModel,
           );
         case "moonshotai":
-          return new MoonshotAIModel(
+          return new MoonshotAILLM(
             {
               thinking: agent.toJSON().thinking,
             },
-            agent.toJSON().model as MoonshotAIModels,
+            agent.toJSON().model as MoonshotAIModel,
           );
         default:
           assertNever(provider);
@@ -161,7 +161,7 @@ export class Runner {
     experiment: ExperimentResource,
     agent: AgentResource,
     mcpClients: Client[],
-    model: BaseModel,
+    model: LLM,
   ): Promise<Result<Runner, SrchdError>> {
     const runner = new Runner(experiment, agent, mcpClients, model);
 


### PR DESCRIPTION
Instead of having plural types like `OpenAIModels`, I simply renamed them to `OpenAIModel`.

To avoid collisions the `BaseModel` class became `LLM` and everything else ensues (e.g. `OpenAIModel->OpenAILLM`)...