### PR TITLE
Fix Peristence Bug with Kubes

### DIFF
--- a/src/computer/definitions.ts
+++ b/src/computer/definitions.ts
@@ -47,6 +47,21 @@ export function defineComputerPod(
     },
     spec: {
       restartPolicy: "Never",
+      initContainers: [
+        {
+          name: "init-workspace",
+          image: COMPUTER_IMAGE,
+          command: [
+            "/bin/bash",
+            "-c",
+            `if [ ! -f /workspace/.initialized ]; then
+              cp -a /home/agent/. /workspace/ 2>/dev/null || true;
+              touch /workspace/.initialized;
+            fi`,
+          ],
+          volumeMounts: [{ name: "workspace", mountPath: "/workspace" }],
+        },
+      ],
       containers: [
         {
           name: "computer",


### PR DESCRIPTION
Currently none of the contents created by the Dockerfile for computers are preserved, as they get overwritten when we mount the PVC. This PR makes sure to copy them into the PVC on first run before doing mounting it.