### PR TITLE
Render tool results more prettily

### DIFF
--- a/src/server/styling.ts
+++ b/src/server/styling.ts
@@ -876,7 +876,11 @@ const renderToolResult = (c: ToolResult, maxPreviewLength = 150) => {
       toolName: c.toolUseName,
       status: c.isError ? "Error" : "Success",
     },
-    JSON.stringify(c.content, null, 2),
+    c.content
+      .map((c) =>
+        c.type === "text" ? c.text : JSON.stringify(c.text, null, 2),
+      )
+      .join("\n"),
     c.isError ? "tool-error" : "tool-success",
   );
 };


### PR DESCRIPTION
Currently tool results can only really be rendered for text. But as it stands they aren't easily readable. This displays the text directly rather than just JSON-stringifying the content:

<img width="864" height="272" alt="Screenshot 2025-11-25 at 10 58 59" src="https://github.com/user-attachments/assets/9accd47d-59ef-4ad7-9c1c-1d3c6ae2e976" />


