### PR TITLE
Rename `workspaceIds` to `namespace`.

### DIFF
--- a/src/computer/definitions.ts
+++ b/src/computer/definitions.ts
@@ -4,24 +4,24 @@ import { podName } from "../lib/k8s";
 export const COMPUTER_IMAGE = "agent-computer:base";
 export const DEFAULT_WORKDIR = "/home/agent";
 
-export function defineComputerLabels(workspaceId: string, computerId: string) {
+export function defineComputerLabels(namespace: string, computerId: string) {
   return {
     app: "srchd",
-    workspace: workspaceId,
+    namespace,
     computer: computerId,
-    "srchd.io/workspace": workspaceId,
+    "srchd.io/namespace": namespace,
     "srchd.io/computer": computerId,
   };
 }
 
 export function defineComputerPod(
-  workspaceId: string,
+  namespace: string,
   computerId: string,
 ): k8s.V1Pod {
   return {
     metadata: {
-      name: podName(workspaceId, computerId),
-      labels: defineComputerLabels(workspaceId, computerId),
+      name: podName(namespace, computerId),
+      labels: defineComputerLabels(namespace, computerId),
     },
     spec: {
       restartPolicy: "Never",

--- a/src/computer/index.ts
+++ b/src/computer/index.ts
@@ -9,7 +9,7 @@ import {
 import { ExperimentResource } from "../resources/experiment";
 import { AgentResource } from "../resources/agent";
 import { podName } from "../lib/k8s";
-import { ensureComputerPod, computerExec } from "./k8s";
+import { computerExec, ensureComputerPod } from "./k8s";
 import { DEFAULT_WORKDIR } from "./definitions";
 import path from "path";
 
@@ -23,45 +23,46 @@ export function computerId(
 }
 
 export class Computer {
-  private workspaceId: string;
+  private namespace: string;
   private computerId: string;
   private podName: string;
 
-  private constructor(workspaceId: string, computerId: string) {
-    this.workspaceId = workspaceId;
+  private constructor(namespace: string, computerId: string) {
+    this.namespace = namespace;
     this.computerId = computerId;
-    this.podName = podName(workspaceId, computerId);
+    this.podName = podName(namespace, computerId);
   }
 
   static async create(
     computerId: string,
-    workspaceId: string = K8S_NAMESPACE,
+    namespace: string = K8S_NAMESPACE,
   ): Promise<Result<Computer, SrchdError>> {
-    let res = await ensureNamespace(workspaceId);
-    if (res.isErr()) {
-      return res;
-    }
-    res = await ensureComputerPod(workspaceId, computerId);
+    let res = await ensureNamespace(namespace);
     if (res.isErr()) {
       return res;
     }
 
-    res = await ensurePodRunning(workspaceId, computerId);
+    res = await ensureComputerPod(namespace, computerId);
     if (res.isErr()) {
       return res;
     }
 
-    return new Ok(new Computer(workspaceId, computerId));
+    res = await ensurePodRunning(namespace, computerId);
+    if (res.isErr()) {
+      return res;
+    }
+
+    return new Ok(new Computer(namespace, computerId));
   }
 
   static async findById(
     computerId: string,
-    workspaceId: string = K8S_NAMESPACE,
+    namespace: string = K8S_NAMESPACE,
   ): Promise<Computer | null> {
-    const name = podName(workspaceId, computerId);
+    const name = podName(namespace, computerId);
     try {
-      await k8sApi.readNamespacedPod({ name, namespace: workspaceId });
-      return new Computer(workspaceId, computerId);
+      await k8sApi.readNamespacedPod({ name, namespace });
+      return new Computer(namespace, computerId);
     } catch (_err) {
       return null;
     }
@@ -69,28 +70,28 @@ export class Computer {
 
   static async ensure(
     computerId: string,
-    workspaceId: string = K8S_NAMESPACE,
+    namespace: string = K8S_NAMESPACE,
   ): Promise<Result<Computer, SrchdError>> {
-    const c = await Computer.findById(computerId, workspaceId);
+    const c = await Computer.findById(computerId, namespace);
     if (c) {
       const status = await c.status();
       if (status !== "Running") {
         // Pod is not running, recreate it
         await c.terminate();
-        return Computer.create(computerId, workspaceId);
+        return Computer.create(computerId, namespace);
       }
       return new Ok(c);
     }
-    return Computer.create(computerId, workspaceId);
+    return Computer.create(computerId, namespace);
   }
 
   static async listComputerIds(
-    workspaceId: string = K8S_NAMESPACE,
+    namespace: string = K8S_NAMESPACE,
   ): Promise<Result<string[], SrchdError>> {
     try {
       const response = await k8sApi.listNamespacedPod({
-        namespace: workspaceId,
-        labelSelector: `srchd.io/workspace=${workspaceId}`,
+        namespace,
+        labelSelector: `srchd.io/namespace=${namespace}`,
       });
 
       const computerIds = response.items
@@ -110,7 +111,7 @@ export class Computer {
     try {
       const pod = await k8sApi.readNamespacedPod({
         name: this.podName,
-        namespace: this.workspaceId,
+        namespace: this.namespace,
       });
       return pod.status?.phase ?? "Unknown";
     } catch (_err) {
@@ -124,7 +125,7 @@ export class Computer {
       try {
         await k8sApi.deleteNamespacedPod({
           name: this.podName,
-          namespace: this.workspaceId,
+          namespace: this.namespace,
           gracePeriodSeconds: 0,
         });
       } catch (_err) {
@@ -136,7 +137,7 @@ export class Computer {
           try {
             await k8sApi.readNamespacedPod({
               name: this.podName,
-              namespace: this.workspaceId,
+              namespace: this.namespace,
             });
           } catch (err: any) {
             if (err.code === 404) {
@@ -200,8 +201,8 @@ export class Computer {
     fullCmd += `cd "${cwd.replace(/"/g, '\\"')}" && ${cmd}`;
 
     const execPromise = computerExec(
-      ["/bin/bash", "-lc", fullCmd],
-      this.workspaceId,
+      [fullCmd],
+      this.namespace,
       this.computerId,
       options?.timeoutMs,
     );

--- a/src/srchd.ts
+++ b/src/srchd.ts
@@ -27,8 +27,8 @@ import {
   publicationMetricsByExperiment,
 } from "./metrics";
 import { ExperimentMetrics } from "./metrics";
-import { Computer, computerId } from "./computer";
 import { buildImage, dockerFile, dockerFileForIdentity } from "./lib/image";
+import { Computer, computerId } from "./computer";
 
 const exitWithError = (err: Err<SrchdError>) => {
   console.error(
@@ -600,30 +600,28 @@ const imageCmd = program.command("image").description("Docker image utils");
 
 imageCmd
   .command("build")
-  .description("Build a Docker image")
-  .argument("[image]: computer | srchd", "Image to build (default: computer)")
-  .option(
-    "-i, --identity <private_key_path>",
-    "Path to SSH private key for Git access (Only for computer image)",
-  )
-  .action(async (image, options) => {
-    const res = await buildImage(image, options.identity);
-    if (res.isErr()) {
-      return exitWithError(res);
-    }
-
-    console.log(`${image} Docker image built successfully.`);
-  });
-
-imageCmd
-  .command("show")
-  .description("Dump the Docker image")
-  .argument("[image]: computer | srchd", "Image to dump (default: computer)")
+  .description("Build a computer Docker image")
   .option(
     "-i, --identity <private_key_path>",
     "Path to SSH private key for Git access",
   )
-  .action(async (image, options) => {
+  .action(async (options) => {
+    const res = await buildImage("computer", options.identity);
+    if (res.isErr()) {
+      return exitWithError(res);
+    }
+
+    console.log(`computer Docker image built successfully.`);
+  });
+
+imageCmd
+  .command("show")
+  .description("Dump the computer Docker image")
+  .option(
+    "-i, --identity <private_key_path>",
+    "Path to SSH private key for Git access",
+  )
+  .action(async (options) => {
     if (options.identity) {
       const res = await dockerFileForIdentity(options.identity);
       if (res.isErr()) {
@@ -631,7 +629,7 @@ imageCmd
       }
       console.log(res.value);
     } else {
-      console.log(await dockerFile(image));
+      console.log(await dockerFile("computer"));
     }
   });
 


### PR DESCRIPTION
As per IRL, instead of productifying the whole thing, lets move back to a kubernetes-centric nomenclature.