### PR TITLE
Adding env vars to settings.json for agent profiles

### DIFF
--- a/agents/research/settings.json
+++ b/agents/research/settings.json
@@ -1,4 +1,5 @@
 {
   "description": "Research agent",
-  "tools": []
+  "tools": [],
+  "env": []
 }

--- a/agents/security/settings.json
+++ b/agents/security/settings.json
@@ -1,5 +1,6 @@
 {
   "description": "Research agent focused on security",
   "tools": ["web", "computer"],
+  "env": [],
   "imageName": "agent-computer:security"
 }

--- a/src/agent_profile.ts
+++ b/src/agent_profile.ts
@@ -3,14 +3,24 @@ import fs from "fs";
 import { readFileContent } from "./lib/fs";
 import { err, ok, Result } from "./lib/error";
 import { isNonDefaultToolName, NonDefaultToolName } from "./tools/constants";
-import { isArrayOf } from "./lib/utils";
+import { isArrayOf, isString } from "./lib/utils";
 
 const AGENT_PROFILES_DIR = path.join(__dirname, "../agents");
+
+// Either the name of a local ENV var to capture, or a name and value pair.
+export type Env = string | [string, string];
+
+export function isEnv(e: any): e is Env {
+  return (
+    isString(e) || (Array.isArray(e) && e.length === 2 && e.every(isString))
+  );
+}
 
 type Settings = {
   description: string;
   tools: NonDefaultToolName[];
   imageName?: string;
+  env: Env[];
 };
 
 function isSettings(obj: any): obj is Settings {
@@ -20,7 +30,9 @@ function isSettings(obj: any): obj is Settings {
     "description" in obj &&
     typeof obj.description === "string" &&
     "tools" in obj &&
-    isArrayOf(obj.tools, isNonDefaultToolName)
+    isArrayOf(obj.tools, isNonDefaultToolName) &&
+    "env" in obj &&
+    isArrayOf(obj.env, isEnv)
   );
 }
 
@@ -90,6 +102,7 @@ export async function getAgentProfile(
   if (promptRes.isErr()) {
     return promptRes;
   }
+
   let dockerFilePath: string | undefined = undefined;
 
   if (settings.tools.includes("computer") && settings.imageName) {

--- a/src/computer/definitions.ts
+++ b/src/computer/definitions.ts
@@ -1,5 +1,7 @@
 import * as k8s from "@kubernetes/client-node";
 import { podName } from "@app/lib/k8s";
+import { Env } from "@app/agent_profile";
+import { isString } from "@app/lib/utils";
 
 export const COMPUTER_IMAGE = "agent-computer:base";
 export const DEFAULT_WORKDIR = "/home/agent";
@@ -18,6 +20,7 @@ export function defineComputerPod(
   namespace: string,
   computerId: string,
   imageName?: string,
+  env: Env[] = [],
 ): k8s.V1Pod {
   return {
     metadata: {
@@ -29,10 +32,40 @@ export function defineComputerPod(
       containers: [
         {
           name: "computer",
+          env: defineComputerEnv(namespace, env),
           image: imageName ?? COMPUTER_IMAGE,
           command: ["/bin/bash", "-c", "tail -f /dev/null"],
         },
       ],
     },
   };
+}
+
+export function defineComputerEnv(
+  namespace: string,
+  env: Env[] = [],
+): k8s.V1EnvVar[] {
+  // Prepare environment variables
+  const envVar: k8s.V1EnvVar[] = [{ name: "NAMESPACE", value: namespace }];
+
+  for (const e of env) {
+    if (isString(e)) {
+      if (process.env[e]) {
+        envVar.push({ name: e, value: process.env[e] });
+      } else {
+        console.warn(`Environment variable ${e} not found. Skipping.`);
+      }
+    } else {
+      envVar.push({ name: e[0], value: e[1] });
+    }
+  }
+
+  if (process.env.OPENAI_API_KEY) {
+    envVar.push({
+      name: "OPENAI_API_KEY",
+      value: process.env.OPENAI_API_KEY,
+    });
+  }
+
+  return envVar;
 }

--- a/src/computer/index.ts
+++ b/src/computer/index.ts
@@ -10,6 +10,7 @@ import { AgentResource } from "@app/resources/agent";
 import { podName } from "@app/lib/k8s";
 import { computerExec, ensureComputerPod } from "./k8s";
 import { DEFAULT_WORKDIR } from "./definitions";
+import { Env } from "@app/agent_profile";
 
 export function computerId(
   experiment: ExperimentResource,
@@ -33,13 +34,14 @@ export class Computer {
     computerId: string,
     namespace: string = K8S_NAMESPACE,
     imageName?: string,
+    env: Env[] = [],
   ): Promise<Result<Computer>> {
     let res = await ensureNamespace(namespace);
     if (res.isErr()) {
       return res;
     }
 
-    res = await ensureComputerPod(namespace, computerId, imageName);
+    res = await ensureComputerPod(namespace, computerId, imageName, env);
     if (res.isErr()) {
       return res;
     }

--- a/src/computer/k8s.ts
+++ b/src/computer/k8s.ts
@@ -9,11 +9,13 @@ import tar from "tar-stream";
 import p from "path";
 import { readFile } from "fs/promises";
 import { addDirectoryToTar } from "@app/lib/image";
+import { Env } from "@app/agent_profile";
 
 export async function ensureComputerPod(
   namespace: string,
   computerId: string,
   imageName?: string,
+  env: Env[] = [],
 ): Promise<Result<void>> {
   const name = podName(namespace, computerId);
   return await ensure(
@@ -26,7 +28,7 @@ export async function ensureComputerPod(
     async () => {
       await k8sApi.createNamespacedPod({
         namespace,
-        body: defineComputerPod(namespace, computerId, imageName),
+        body: defineComputerPod(namespace, computerId, imageName, env),
       });
     },
     "Pod",

--- a/src/srchd.ts
+++ b/src/srchd.ts
@@ -296,6 +296,7 @@ agentCmd
           computerId(experiment, agent),
           undefined,
           profile.imageName,
+          profile.env,
         );
       }
     }


### PR DESCRIPTION
ENV vars cannot be hardcoded in the Dockerfiles with e.g.
```Dockerfile
ENV MY_ENV_VAR={$MY_LOCAL_COPY}
```
Due to how the `k8s` SDK works, they have to be passed as an argument to the pod definition.

Here we give the option to define env vars we want to pull from the local system into it.

In a `settings.json` we can give an array of vars:

```json
{
  "env": [
    "MY_LOCAL_VAR", 
    "MY_OTHER_LOCAL_VAR", 
    ["MY_NON_LOCAL_VAR", "and-its-corresponding-value"],
    "MY_LAST_LOCAL_VAR"
  ]
}
```

As you can see you can either give the name of local variables, to be captured from `process.env` or you can directly specify name-value pairs.