### PR TITLE
Lint Fix

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,78 +3,64 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: [
-      ".prettierrc.js",
-      "eslint.config.ts",
-      "**/*.config.js",
-      "**/node_modules/**",
-      "**/out/**",
-      "**/dist/**",
-      "**/build/**",
-      "**/migrations/**",
-    ],
+    ignores: ["**/node_modules/**", "**/dist/**", "**/build/**"],
   },
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.recommended,
+  ...tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ["*.js"],
-        },
+        project: "./tsconfig.json",
         tsconfigRootDir: import.meta.dirname,
       },
     },
-  rules: {
-    // Enforce trailing commas wherever possible
-    "comma-dangle": [
-      "error",
-      {
-        arrays: "always-multiline",
-        objects: "always-multiline",
-        imports: "always-multiline",
-        exports: "always-multiline",
-        functions: "always-multiline",
-      },
-    ],
-    // Allow explicit any types
-    "@typescript-eslint/no-explicit-any": "off",
-    // Disable all 'any' type safety rules
-    "@typescript-eslint/no-unsafe-argument": "off",
-    "@typescript-eslint/no-unsafe-assignment": "off",
-    "@typescript-eslint/no-unsafe-call": "off",
-    "@typescript-eslint/no-unsafe-member-access": "off",
-    "@typescript-eslint/no-unsafe-return": "off",
-    "@typescript-eslint/no-base-to-string": "off",
-    // Allow @ts-ignore comments
-    "@typescript-eslint/ban-ts-comment": [
-      "error",
-      {
-        "ts-ignore": "allow-with-description",
-      },
-    ],
-    // Allow lexical declarations in case blocks
-    "no-case-declarations": "off",
-    // Prefer nullish coalescing operator (??) over logical OR (||)
-    "@typescript-eslint/prefer-nullish-coalescing": "error",
-    // Allow async functions without await
-    "@typescript-eslint/require-await": "off",
-    // Allow floating promises
-    "@typescript-eslint/no-floating-promises": "off",
-    // Allow switch cases without break when they have returns
-    "no-fallthrough": [
-      "error",
-      {
-        allowEmptyCase: true,
-      },
-    ],
-    // Allow unused variables if they start with _
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        caughtErrorsIgnorePattern: "^_",
-      },
-    ],
+    rules: {
+      // Enforce trailing commas wherever possible
+      "comma-dangle": [
+        "error",
+        {
+          arrays: "always-multiline",
+          objects: "always-multiline",
+          imports: "always-multiline",
+          exports: "always-multiline",
+          functions: "always-multiline",
+        },
+      ],
+      // Allow explicit any types
+      "@typescript-eslint/no-explicit-any": "off",
+      // Allow @ts-ignore comments
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-ignore": "allow-with-description",
+        },
+      ],
+      // Allow lexical declarations in case blocks
+      "no-case-declarations": "off",
+      // Prefer nullish coalescing operator (??) over logical OR (||)
+      "@typescript-eslint/prefer-nullish-coalescing": "error",
+      // Disable opinionated stylistic rules
+      "@typescript-eslint/consistent-type-definitions": "off",
+      "@typescript-eslint/no-inferrable-types": "off",
+      "@typescript-eslint/consistent-indexed-object-style": "off",
+      "@typescript-eslint/prefer-optional-chain": "off",
+      "@typescript-eslint/prefer-regexp-exec": "off",
+      // Allow switch cases without break when they have returns
+      "no-fallthrough": [
+        "error",
+        {
+          allowEmptyCase: true,
+        },
+      ],
+      // Allow unused variables if they start with _
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
   },
-});
+);

--- a/src/srchd.ts
+++ b/src/srchd.ts
@@ -467,7 +467,6 @@ agentCmd
       while (true) {
         const tick = await runner.tick();
         if (tick.isErr()) {
-          // eslint-disable-next-line
           throw tick;
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,7 +8,6 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
     "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
@@ -24,14 +22,15 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {
-      "@app/*": ["src/*"]
+      "@app/*": [
+        "src/*"
+      ]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -47,12 +46,10 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -75,7 +72,6 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
@@ -85,7 +81,6 @@
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
@@ -107,7 +102,6 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */


### PR DESCRIPTION
Fixes ESLint out of memory errors.

After the `npm audit` ([7e9ff31](https://github.com/dust-tt/srchd/pull/132/commits/7e9ff3195bc9d436c1f7a880f45bb282d1f0b7d2)), the `node_modules` had much higher `.ts` file counts, which meant the full `recommendedTypeChecked` was failing due to running on more that 5k files. (Even when ignoring the `node_modules` directory they still get parsed since they are imported by our own code). 

- Changed to `stylisticTypeChecked` which does things like `prefer-nullish-coalescing` and others (most of what was in `recommendedTypeChecked` was disabled by our previous ESlint config rules).  And we already run `npx tsc --noEmit` in the workflow as well anyways.

