### PR TITLE
[codex] Add latest model options

### DIFF
--- a/src/models/deepseek/index.ts
+++ b/src/models/deepseek/index.ts
@@ -19,9 +19,9 @@ import { removeNulls } from "@app/lib/utils";
 import { convertToolChoice } from "../openai";
 import { CompletionUsage } from "openai/resources/completions";
 
-export type DeepseekModel = "deepseek-chat" | "deepseek-reasoner";
+export type DeepseekModel = "deepseek-chat" | "deepseek-reasoner" | "deepseek-v4-pro";
 export function isDeepseekModel(model: string): model is DeepseekModel {
-  return ["deepseek-chat", "deepseek-reasoner"].includes(model);
+  return ["deepseek-chat", "deepseek-reasoner", "deepseek-v4-pro"].includes(model);
 }
 
 type DeepseekTokenPrices = {
@@ -46,6 +46,7 @@ function normalizeTokenPrices(
 const TOKEN_PRICING: Record<DeepseekModel, DeepseekTokenPrices> = {
   "deepseek-chat": normalizeTokenPrices(0.28, 0.42, 0.028),
   "deepseek-reasoner": normalizeTokenPrices(0.28, 0.42, 0.028),
+  "deepseek-v4-pro": normalizeTokenPrices(1.74, 3.48, 0.145),
 };
 
 export class DeepseekLLM extends LLM {
@@ -142,7 +143,18 @@ export class DeepseekLLM extends LLM {
           model: this.model,
           messages: input,
           // 32K is the default, but we want to be able to use the full context window
-          max_completion_tokens: this.model === "deepseek-reasoner" ? (this.config.thinking && this.config.thinking === "high" ? 64000 : 32000) : 8000,
+          max_completion_tokens: (() => {
+            switch (this.model) {
+              case "deepseek-reasoner":
+                return this.config.thinking && this.config.thinking === "high" ? 64000 : 32000;
+              case "deepseek-v4-pro":
+                return this.config.thinking && this.config.thinking === "high" ? 128000 : 64000;
+              case "deepseek-chat":
+                return 8000;
+              default:
+                assertNever(this.model);
+            }
+          })(),
           tool_choice: convertToolChoice(toolChoice),
           tools: tools.map((tool) => ({
             type: "function",
@@ -275,6 +287,8 @@ export class DeepseekLLM extends LLM {
         return 128000;
       case "deepseek-reasoner":
         return 128000;
+      case "deepseek-v4-pro":
+        return 1000000;
       default:
         assertNever(this.model);
     }

--- a/src/models/gemini.ts
+++ b/src/models/gemini.ts
@@ -20,13 +20,13 @@ import { assertNever } from "@app/lib/assert";
 import { removeNulls } from "@app/lib/utils";
 
 export type GeminiModel =
-  | "gemini-3-pro-preview"
+  | "gemini-3.1-pro-preview"
   | "gemini-2.5-pro"
   | "gemini-2.5-flash"
   | "gemini-2.5-flash-lite";
 export function isGeminiModel(model: string): model is GeminiModel {
   return [
-    "gemini-3-pro-preview",
+    "gemini-3.1-pro-preview",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
@@ -50,7 +50,7 @@ function normalizeTokenPrices(
 
 // https://ai.google.dev/gemini-api/docs/pricing
 const TOKEN_PRICING: Record<GeminiModel, GeminiTokenPrices> = {
-  "gemini-3-pro-preview": normalizeTokenPrices(2, 12),
+  "gemini-3.1-pro-preview": normalizeTokenPrices(2, 12),
   "gemini-2.5-pro": normalizeTokenPrices(1.25, 10),
   "gemini-2.5-flash": normalizeTokenPrices(0.3, 2.5),
   "gemini-2.5-flash-lite": normalizeTokenPrices(0.1, 0.4),
@@ -315,7 +315,7 @@ export class GeminiLLM extends LLM {
       case "gemini-2.5-flash":
       case "gemini-2.5-flash-lite":
         return 1048576 - 65536;
-      case "gemini-3-pro-preview":
+      case "gemini-3.1-pro-preview":
         return 200000 - 65536;
       default:
         assertNever(this.model);

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -48,6 +48,7 @@ const TOKEN_PRICING: Record<OpenAIModel, OpenAITokenPrices> = {
   "gpt-5.2-codex": normalizeTokenPrices(1.75, 14),
   "gpt-5.3-codex": normalizeTokenPrices(1.75, 14),
   "gpt-5.4": normalizeTokenPrices(2.50, 15),
+  "gpt-5.5": normalizeTokenPrices(5, 30, 0.5),
 };
 
 export function convertToolChoice(toolChoice: ToolChoice) {
@@ -88,7 +89,8 @@ export type OpenAIModel =
   | "gpt-5.2"
   | "gpt-5.2-codex"
   | "gpt-5.3-codex"
-  | "gpt-5.4";
+  | "gpt-5.4"
+  | "gpt-5.5";
 export function isOpenAIModel(model: string): model is OpenAIModel {
   return [
     "gpt-4.1",
@@ -102,6 +104,7 @@ export function isOpenAIModel(model: string): model is OpenAIModel {
     "gpt-5.2-codex",
     "gpt-5.3-codex",
     "gpt-5.4",
+    "gpt-5.5",
   ].includes(model);
 }
 
@@ -386,6 +389,7 @@ export class OpenAILLM extends LLM {
       case "gpt-5.2-codex":
       case "gpt-5.3-codex":
       case "gpt-5.4":
+      case "gpt-5.5":
         return 400000 - 128000;
       // Real context size, start with 400k (cost for now)
       // case "gpt-5.4":

--- a/src/models/zhipu.ts
+++ b/src/models/zhipu.ts
@@ -18,9 +18,9 @@ import { removeNulls } from "@app/lib/utils";
 import { convertToolChoice } from "./openai";
 import { CompletionUsage } from "openai/resources/completions";
 
-export type ZhipuModel = "glm-5" | "glm-5-code";
+export type ZhipuModel = "glm-5.1" | "glm-5" | "glm-5-code";
 export function isZhipuModel(model: string): model is ZhipuModel {
-  return ["glm-5", "glm-5-code"].includes(model);
+  return ["glm-5.1", "glm-5", "glm-5-code"].includes(model);
 }
 
 type ZhipuTokenPrices = {
@@ -43,6 +43,7 @@ function normalizeTokenPrices(
 
 // https://docs.z.ai/guides/overview/pricing
 const TOKEN_PRICING: Record<ZhipuModel, ZhipuTokenPrices> = {
+  "glm-5.1": normalizeTokenPrices(1.4, 4.4, 0.26),
   "glm-5": normalizeTokenPrices(1, 3.2, 0.2),
   "glm-5-code": normalizeTokenPrices(1.2, 5, 0.3),
 };
@@ -246,6 +247,7 @@ export class ZhipuLLM extends LLM {
     switch (this.model) {
       case "glm-5":
       case "glm-5-code":
+      case "glm-5.1":
         return 200000;
       default:
         assertNever(this.model);


### PR DESCRIPTION
## Summary

Adds selected latest model IDs and pricing/context metadata to the model provider registries:

- OpenAI: `gpt-5.5`, keeping the existing 400K working context constraint.
- Gemini: replaces `gemini-3-pro-preview` with `gemini-3.1-pro-preview`, capped to the requested 200K context.
- DeepSeek: adds `deepseek-v4-pro` with V4 Pro pricing and larger completion budget.
- Z.AI: adds `glm-5.1` with current pricing and 200K context.

## Validation

- `npm run typecheck` was run and failed on existing `src/server/experiments.ts` route parameter typing errors unrelated to these model files.
- `npm run lint` was run and failed on existing unrelated issues in `src/computer/process.ts` and `src/scripts/dump_publications_with_attachments.ts`.

No unrelated files were changed.